### PR TITLE
Bugfix for getItemLayout

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ export default class AlphabetFlatList extends Component {
             scrollEventThrottle={16}
             onViewableItemsChanged={this.onViewableItemsChanged}
             extraData={this.props}
-            getItemLayout={this.getItemLayout}
+            getItemLayout={this.props.getItemLayout}
             {...this.props}
           />
         </View>


### PR DESCRIPTION
As it is a required prop, it should be added before `...this.props` to maintain the required privilege but as it is not defined in the class, it should be inside the props.